### PR TITLE
Provide option to reference your own root CA and fix parsing of boolean / numeric options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,9 @@
 
-# 1.0.0 - 201_-__-__
+# 1.0.1 - 2018-10-23
+
+- Added support for custom root CAs
+- Fixed parsing of option values
+
+# 1.0.0 - 2018-10-21
 
 - initial release

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ exports.hook_capabilities = function (next, connection) {
     next();
 };
 
+const ca_cache = {}
 exports.check_plain_passwd = function (connection, user, passwd, cb) {
     const plugin = this;
     let trace_imap = false;
@@ -67,6 +68,12 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
     }
     if (sect.tls) {
         config.tls = (sect.tls === 'true');
+    }
+    if (sect.ca) {
+        if (!ca_cache[section_name]) {
+            ca_cache[section_name] = require('fs').readFileSync(sect.ca);
+        }
+        config.tlsOptions = {ca: [ca_cache[section_name]]};
     }
     if (sect.rejectUnauthorized) {
         if (!config.tlsOptions) {

--- a/index.js
+++ b/index.js
@@ -66,18 +66,19 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
         config.port = sect.port;
     }
     if (sect.tls) {
-        config.tls = sect.tls;
+        config.tls = (sect.tls === 'true');
     }
     if (sect.rejectUnauthorized) {
-        config.tlsOptions = {
-            rejectUnauthorized: sect.rejectUnauthorized
-        };
+        if (!config.tlsOptions) {
+            config.tlsOptions = {};
+        }
+        config.tlsOptions.rejectUnauthorized = (sect.rejectUnauthorized === 'true');
     }
     if (sect.connTimeout) {
-        config.connTimeout = sect.connTimeout;
+        config.connTimeout = parseInt(sect.connTimeout, 10);
     }
     if (sect.authTimeout) {
-        config.authTimeout = sect.authTimeout;
+        config.authTimeout = parseInt(sect.authTimeout, 10);
     }
 
     if (sect.users) {

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
         tls: sect.tls,
         tlsOptions: {
             rejectUnauthorized: sect.rejectUnauthorized
-        };
+        }
     };
 
     if (sect.trace_imap == 'true') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-auth-imap",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Haraka plugin that frobnicates email connections",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This might be a better option than just ignoring all certificate checks via the `rejectUnauthorized` option.

If `rejectUnauthorized` is set to false, it is still set to true since the value will be `'false'`.